### PR TITLE
fix: 게시글 API 필드 누락 보완 및 PATCH 메서드 허용

### DIFF
--- a/src/main/java/cotw/server/common/security/CorsMvcConfig.java
+++ b/src/main/java/cotw/server/common/security/CorsMvcConfig.java
@@ -11,7 +11,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*");
     }
 }

--- a/src/main/java/cotw/server/common/security/SecurityConfig.java
+++ b/src/main/java/cotw/server/common/security/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
         http.cors(cors -> cors.configurationSource(request -> {
             CorsConfiguration config = new CorsConfiguration();
             config.setAllowedOrigins(List.of("http://localhost:5173"));
-            config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
             config.setAllowedHeaders(List.of("*"));
             config.setExposedHeaders(List.of("Authorization"));
             config.setMaxAge(3600L);
@@ -104,6 +104,14 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/auth/login", "/", "/auth/signup").permitAll()
                         .requestMatchers("/reissue").permitAll()
+
+                        // 공개 목록 조회는 누구나
+                        .requestMatchers(HttpMethod.GET, "/api/posts").permitAll()
+                        // 단일 게시글 조회는 정책에 맞게 (공개글은 누구나, 비공개는 서버에서 검사)
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                        // 게시글 생성은 관리자/단체만
+                        .requestMatchers(HttpMethod.POST, "/api/posts").hasAnyRole("ADMIN", "ORGANIZATION")
+
 //                        .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated());
 

--- a/src/main/java/cotw/server/domain/board/controller/PostController.java
+++ b/src/main/java/cotw/server/domain/board/controller/PostController.java
@@ -6,8 +6,10 @@ import cotw.server.domain.board.dto.request.PostUpdateRequestDto;
 import cotw.server.domain.board.dto.response.PostListResponseDto;
 import cotw.server.domain.board.dto.response.PostResponseDto;
 import cotw.server.domain.board.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,8 +27,10 @@ public class PostController {
      * - 로그인한 사용자만 가능
      * - 작성 시 기본 isPublic = false (비공개)
      */
+    @PreAuthorize("hasAnyRole('ADMIN','ORGANIZATION')")
     @PostMapping
-    public ResponseEntity<?> createPost(@AuthenticationPrincipal CustomUserDetails principal, @RequestBody PostCreateRequestDto dto) {
+    public ResponseEntity<?> createPost(@AuthenticationPrincipal CustomUserDetails principal,
+                                        @Valid @RequestBody PostCreateRequestDto dto) {
         Long postId = postService.createPost(dto, principal.getUsername());
         return ResponseEntity.ok(postId);
     }
@@ -83,6 +87,7 @@ public class PostController {
      * - 관리자만 가능
      * - 작성 시 기본 false → 관리자가 true로 변경하면 공개됨
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{postId}/visibility")
     public ResponseEntity<Void> changePostVisibility(
             @AuthenticationPrincipal CustomUserDetails principal,

--- a/src/main/java/cotw/server/domain/board/controller/PostController.java
+++ b/src/main/java/cotw/server/domain/board/controller/PostController.java
@@ -3,6 +3,7 @@ package cotw.server.domain.board.controller;
 import cotw.server.common.jwt.CustomUserDetails;
 import cotw.server.domain.board.dto.request.PostCreateRequestDto;
 import cotw.server.domain.board.dto.request.PostUpdateRequestDto;
+import cotw.server.domain.board.dto.response.PostListResponseDto;
 import cotw.server.domain.board.dto.response.PostResponseDto;
 import cotw.server.domain.board.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -89,5 +90,16 @@ public class PostController {
             @RequestParam boolean isPublic) {
         postService.changePostVisibility(postId, isPublic, principal.getUsername());
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 공개된 모든 게시글 목록 조회
+     * - 로그인 여부와 관계없이 접근 가능
+     * - 비공개 게시글은 제외하고, isPublic = true 인 게시글만 반환
+     */
+    @GetMapping
+    public ResponseEntity<List<PostListResponseDto>> getAllPublicPosts() {
+        List<PostListResponseDto> posts = postService.getAllPublicPosts();
+        return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
@@ -4,9 +4,13 @@ import cotw.server.domain.board.entity.Category;
 import cotw.server.domain.board.entity.Image;
 import cotw.server.domain.board.entity.Post;
 import cotw.server.domain.member.entity.Member;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,17 +18,24 @@ import java.util.List;
 @NoArgsConstructor
 public class PostCreateRequestDto {
 
+    @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
+    @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
+    @NotNull(message = "카테고리를 선택하세요.")
     private Category category;
 
     // 총 목표 금액
+    @Min(value = 1, message = "목표 금액은 1원 이상이어야 합니다.")
     private int amount;
 
-    // 업로드된 이미지 경로 리스트
+    // 이미지 경로 리스트
     private List<String> imageUrls;
+
+    @NotNull(message = "기부 마감일은 필수입니다.")
+    private LocalDate deadline;
 
     // Post 엔티티로 변환
     public Post toPostEntity(Member author) {
@@ -36,6 +47,7 @@ public class PostCreateRequestDto {
                 .currentAmount(0)
                 .author(author)
                 .isPublic(false)
+                .deadline(deadline)
                 .build();
     }
 

--- a/src/main/java/cotw/server/domain/board/dto/response/PostListResponseDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/response/PostListResponseDto.java
@@ -1,0 +1,30 @@
+package cotw.server.domain.board.dto.response;
+
+import cotw.server.domain.board.entity.Post;
+import lombok.Getter;
+
+@Getter
+public class PostListResponseDto {
+    private Long id;
+    private String title;
+    private String category; // 예: "아동", "장애인" (displayName)
+    private int target;      // = amount
+    private int raised;      // = currentAmount
+    private double percent;  // = raised / target * 100
+    private int remaining;   // = target - raised
+    private String image;    // 대표 이미지 URL(없으면 null)
+
+    // DB 매핑용 생성자
+    public PostListResponseDto(Post post) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        // enum → 한글 표시명으로
+        this.category = post.getCategory().getDisplayName();
+        this.target = post.getAmount();
+        this.raised = post.getCurrentAmount();
+        this.remaining = target - raised;
+        this.percent = (target > 0) ? (raised / (double) target) * 100 : 0.0;
+        this.image = post.getImages().isEmpty() ? null : post.getImages().get(0).getImageUrl();
+    }
+
+}

--- a/src/main/java/cotw/server/domain/board/dto/response/PostResponseDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/response/PostResponseDto.java
@@ -1,10 +1,13 @@
 package cotw.server.domain.board.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import cotw.server.domain.board.entity.Category;
 import cotw.server.domain.board.entity.Image;
 import cotw.server.domain.board.entity.Post;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +21,11 @@ public class PostResponseDto {
     private Category category;
     private int amount;
     private int currentAmount;
+    private LocalDate deadline;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime updatedAt;
     private List<String> imageUrls;
 
     public PostResponseDto(Post post) {
@@ -28,6 +36,9 @@ public class PostResponseDto {
         this.category = post.getCategory();
         this.amount = post.getAmount();
         this.currentAmount = post.getCurrentAmount();
+        this.deadline = post.getDeadline();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
         List<String> imageUrls = new ArrayList<>();
         for (Image image : post.getImages()) {
             imageUrls.add(image.getImageUrl());

--- a/src/main/java/cotw/server/domain/board/entity/Post.java
+++ b/src/main/java/cotw/server/domain/board/entity/Post.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,10 @@ public class Post extends BaseEntity {
     // 공개 여부
     @Column(nullable = false)
     private boolean isPublic;
+
+    // 기부 마감일
+    @Column(nullable=false)
+    private LocalDate deadline;
 
     // 이미지 리스트
     @Builder.Default

--- a/src/main/java/cotw/server/domain/board/service/PostService.java
+++ b/src/main/java/cotw/server/domain/board/service/PostService.java
@@ -2,6 +2,7 @@ package cotw.server.domain.board.service;
 
 import cotw.server.domain.board.dto.request.PostCreateRequestDto;
 import cotw.server.domain.board.dto.request.PostUpdateRequestDto;
+import cotw.server.domain.board.dto.response.PostListResponseDto;
 import cotw.server.domain.board.dto.response.PostResponseDto;
 import cotw.server.domain.board.entity.Image;
 import cotw.server.domain.board.entity.Post;
@@ -153,4 +154,17 @@ public class PostService {
         post.changeVisibility(isPublic);
     }
 
+    /**
+     * 공개 상태의 모든 게시글 조회
+     * - isPublic = true 조건에 해당하는 게시글만 DB에서 조회
+     */
+    @Transactional(readOnly = true)
+    public List<PostListResponseDto> getAllPublicPosts() {
+        // 공개 글만 조회
+        List<Post> posts = postRepository.findAllByIsPublicTrue();
+
+        return posts.stream()
+                .map(PostListResponseDto::new)
+                .toList();
+    }
 }

--- a/src/main/java/cotw/server/domain/board/service/PostService.java
+++ b/src/main/java/cotw/server/domain/board/service/PostService.java
@@ -15,6 +15,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -26,8 +27,9 @@ public class PostService {
 
     /**
      * 게시글 생성
-     * - 로그인한 사용자만 가능
-     * - 기본적으로 isPublic = false로 저장 (Post 엔티티에서 기본값 설정)
+     * - 기본 비공개(isPublic=false)
+     * - 마감일은 오늘 이후
+     * - 첫 번째 이미지 썸네일 지정
      */
     @Transactional
     public Long createPost(PostCreateRequestDto dto, String authorEmail) {
@@ -36,10 +38,13 @@ public class PostService {
         Member author = memberRepository.findByEmail(authorEmail)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // Post 엔티티 생성
-        Post post = dto.toPostEntity(author);
+        // 마감일 검증: 오늘 이후
+        if (!dto.getDeadline().isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("기부 마감일은 오늘 이후여야 합니다.");
+        }
 
-        // 이미지 엔티티 리스트 생성 & Post와 연관관계 설정
+        // 엔티티 생성 및 이미지 바인딩
+        Post post = dto.toPostEntity(author);
         List<Image> images = dto.toImageEntityList(post);
         images.forEach(post::addImage);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#10 
## ✅ 작업 내용
- 게시글 API에 누락된 필드 추가 (모금 시작일, 마감일 등)
- PATCH 메서드 보안 설정 및 CORS 허용
## 리뷰 요구사항 (선택)

## 기타 (선택)