### PR TITLE
feat: 게시글 생성·수정 시 이미지 처리 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-retry:2.2.0'
     implementation 'io.github.resilience4j:resilience4j-bulkhead:2.2.0'
     implementation 'io.github.resilience4j:resilience4j-timelimiter:2.2.0'
+
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.700'
 }
 
 tasks.named('test') {

--- a/src/main/java/cotw/server/common/config/S3Config.java
+++ b/src/main/java/cotw/server/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package cotw.server.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${aws.accessKey}")
+    private String accessKey;
+
+    @Value("${aws.secretKey}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return  (AmazonS3Client) AmazonS3Client.builder()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/cotw/server/common/jwt/LoginFilter.java
+++ b/src/main/java/cotw/server/common/jwt/LoginFilter.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,6 +25,7 @@ import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/cotw/server/domain/board/controller/PostController.java
+++ b/src/main/java/cotw/server/domain/board/controller/PostController.java
@@ -12,8 +12,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/posts")
@@ -114,5 +117,11 @@ public class PostController {
     @GetMapping("/home")
     public ResponseEntity<List<PostListResponseDto>> getHomePosts() {
         return ResponseEntity.ok(postService.getHomePosts());
+    }
+
+    @PostMapping("/upload")
+    public Map<String, String> upload(@RequestPart("file") MultipartFile file) throws IOException {
+        String imageUrl = postService.upload(file);
+        return Map.of("url", imageUrl);
     }
 }

--- a/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
@@ -6,6 +6,7 @@ import cotw.server.domain.board.entity.Post;
 import cotw.server.domain.member.entity.Member;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,6 +33,7 @@ public class PostCreateRequestDto {
     private int amount;
 
     // 이미지 경로 리스트
+    @NotEmpty(message = "이미지는 최소 1개 이상 등록해야 합니다.")
     private List<String> imageUrls;
 
     @NotNull(message = "기부 마감일은 필수입니다.")

--- a/src/main/java/cotw/server/domain/board/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/request/PostUpdateRequestDto.java
@@ -4,6 +4,8 @@ import cotw.server.domain.board.entity.Category;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class PostUpdateRequestDto {
@@ -11,4 +13,5 @@ public class PostUpdateRequestDto {
     private String content;
     private Category category;
     private int amount;
+    private List<String> imageUrls;
 }

--- a/src/main/java/cotw/server/domain/board/entity/Post.java
+++ b/src/main/java/cotw/server/domain/board/entity/Post.java
@@ -121,4 +121,9 @@ public class Post extends BaseEntity {
         this.participants.add(participant);
 
     }
+
+    // 기존 이미지 전체 제거
+    public void clearImages() {
+        this.images.clear();
+    }
 }

--- a/src/main/java/cotw/server/domain/board/service/PostService.java
+++ b/src/main/java/cotw/server/domain/board/service/PostService.java
@@ -1,5 +1,7 @@
 package cotw.server.domain.board.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import cotw.server.domain.board.dto.request.PostCreateRequestDto;
 import cotw.server.domain.board.dto.request.PostUpdateRequestDto;
 import cotw.server.domain.board.dto.response.PostListResponseDto;
@@ -11,13 +13,17 @@ import cotw.server.domain.member.entity.Member;
 import cotw.server.domain.member.entity.Role;
 import cotw.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +31,10 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+
+    private final AmazonS3Client s3Client;
+    @Value("${aws.s3.bucket}")
+    private String bucket;
 
     /**
      * 게시글 생성
@@ -137,6 +147,22 @@ public class PostService {
         }
 
         post.update(dto);
+
+        // 1) 기존 이미지 삭제
+        post.clearImages();
+
+        // 2) 새 이미지 등록
+        if (dto.getImageUrls() != null && !dto.getImageUrls().isEmpty()) {
+            for (int i = 0; i < dto.getImageUrls().size(); i++) {
+                Image img = Image.builder()
+                        .post(post)
+                        .imageUrl(dto.getImageUrls().get(i))
+                        .isThumbnail(i == 0)   // 첫 번째 이미지를 썸네일로
+                        .orderIndex(i)
+                        .build();
+                post.addImage(img);
+            }
+        }
     }
 
     /**
@@ -187,5 +213,30 @@ public class PostService {
         return top6.stream()
                 .map(PostListResponseDto::new)
                 .toList();
+    }
+
+    // 파일 업로드
+    public String upload(MultipartFile image) throws IOException {
+        // 원본 파일명
+        String originalFileName = image.getOriginalFilename();
+
+        // 저장할 파일명 (UUID 붙여 중복 방지)
+        String fileName = changeFileName(originalFileName);
+
+        // S3 메타데이터 생성
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(image.getContentType());
+        metadata.setContentLength(image.getSize());
+
+        // S3에 업로드
+        s3Client.putObject(bucket, fileName, image.getInputStream(), metadata);
+
+        // 업로드된 파일의 접근 URL 반환
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 파일명 변경 메서드 (UUID_원본파일명)
+    private String changeFileName(String originalFileName) {
+        return UUID.randomUUID().toString() + "_" + originalFileName;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#10 
## ✅ 작업 내용
- 게시글 생성 시 이미지 업로드 기능 추가
- 게시글 수정 시 이미지 추가/삭제/유지 가능
## 리뷰 요구사항 (선택)

## 기타 (선택)
- `application-dev.yml`에 AWS S3 관련 설정 추가 필요