### PR TITLE
feat: 공지사항 이미지 업로드 및 게시글 공개 설정 기능 추가

### DIFF
--- a/src/main/java/cotw/server/common/security/SecurityConfig.java
+++ b/src/main/java/cotw/server/common/security/SecurityConfig.java
@@ -117,6 +117,7 @@ public class SecurityConfig {
 
                 // 관리자 전용
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.PATCH, "/api/posts/visibility").hasRole("ADMIN")
 
                 .anyRequest().authenticated()
         );

--- a/src/main/java/cotw/server/domain/board/controller/NoticeController.java
+++ b/src/main/java/cotw/server/domain/board/controller/NoticeController.java
@@ -6,8 +6,11 @@ import cotw.server.domain.board.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/notices")
@@ -16,27 +19,42 @@ public class NoticeController {
 
     private final NoticeService noticeService;
 
+    /**
+     * 공지사항 생성
+     */
     @PostMapping
     public ResponseEntity<NoticeResponseDto> create(@RequestBody NoticeRequestDto dto) {
         return ResponseEntity.ok(noticeService.createNotice(dto));
     }
 
+    /**
+     * 모든 공지사항 조회
+     */
     @GetMapping
     public ResponseEntity<List<NoticeResponseDto>> getAll() {
         return ResponseEntity.ok(noticeService.getAllNotices());
     }
 
+    /**
+     * 공지사항 단건 조회
+     */
     @GetMapping("/{id}")
     public ResponseEntity<NoticeResponseDto> getOne(@PathVariable Long id) {
         return ResponseEntity.ok(noticeService.getNotice(id));
     }
 
-    @PutMapping("/{id}")
+    /**
+     * 공지사항 수정
+     */
+    @PatchMapping("/{id}")
     public ResponseEntity<NoticeResponseDto> update(@PathVariable Long id,
                                                     @RequestBody NoticeRequestDto dto) {
         return ResponseEntity.ok(noticeService.updateNotice(id, dto));
     }
 
+    /**
+     * 공지사항 삭제
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         noticeService.deleteNotice(id);

--- a/src/main/java/cotw/server/domain/board/controller/PostController.java
+++ b/src/main/java/cotw/server/domain/board/controller/PostController.java
@@ -90,13 +90,19 @@ public class PostController {
      * - 관리자만 가능
      * - 작성 시 기본 false → 관리자가 true로 변경하면 공개됨
      */
-    @PreAuthorize("hasRole('ADMIN')")
-    @PatchMapping("/{postId}/visibility")
+    @PatchMapping("/visibility")
     public ResponseEntity<Void> changePostVisibility(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @PathVariable Long postId,
-            @RequestParam boolean isPublic) {
-        postService.changePostVisibility(postId, isPublic, principal.getUsername());
+            @RequestBody Map<String, Object> body) {
+        @SuppressWarnings("unchecked")
+        List<Integer> postIds = (List<Integer>) body.get("postIds");
+        boolean isPublic = (Boolean) body.get("isPublic");
+
+        postService.changePostsVisibility(
+                postIds.stream().map(Long::valueOf).toList(),
+                isPublic,
+                principal.getUsername()
+        );
         return ResponseEntity.ok().build();
     }
 
@@ -153,8 +159,11 @@ public class PostController {
         return ResponseEntity.ok(postService.getHomePosts());
     }
 
+    /**
+     * 이미지 업로드
+     */
     @PostMapping("/upload")
-    public Map<String, String> upload(@RequestPart("file") MultipartFile file) throws IOException {
+    public Map<String, String> uploadImage(@RequestPart("file") MultipartFile file) throws IOException {
         String imageUrl = postService.upload(file);
         return Map.of("url", imageUrl);
     }

--- a/src/main/java/cotw/server/domain/board/dto/request/NoticeRequestDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/request/NoticeRequestDto.java
@@ -3,10 +3,13 @@ package cotw.server.domain.board.dto.request;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class NoticeRequestDto {
     private String title;
     private String content;
     private Boolean isPinned;
+    private List<String> imageUrls;
 }

--- a/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/request/PostCreateRequestDto.java
@@ -33,7 +33,6 @@ public class PostCreateRequestDto {
     private int amount;
 
     // 이미지 경로 리스트
-    @NotEmpty(message = "이미지는 최소 1개 이상 등록해야 합니다.")
     private List<String> imageUrls;
 
     @NotNull(message = "기부 마감일은 필수입니다.")
@@ -56,11 +55,11 @@ public class PostCreateRequestDto {
     // 이미지 URL들을 Image 엔티티 리스트로 변환
     public List<Image> toImageEntityList(Post post) {
         List<Image> images = new ArrayList<>();
-        if (imageUrls != null) {
+        if (imageUrls != null && !imageUrls.isEmpty()) {
             for (int i = 0; i < imageUrls.size(); i++) {
                 images.add(Image.builder()
                         .imageUrl(imageUrls.get(i))
-                        .isThumbnail(i == 0) // 첫 번째 이미지를 썸네일로 설정
+                        .isThumbnail(i == 0)
                         .orderIndex(i)
                         .post(post)
                         .build());

--- a/src/main/java/cotw/server/domain/board/dto/response/NoticeResponseDto.java
+++ b/src/main/java/cotw/server/domain/board/dto/response/NoticeResponseDto.java
@@ -4,6 +4,7 @@ import cotw.server.domain.board.entity.Notice;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class NoticeResponseDto {
@@ -12,6 +13,7 @@ public class NoticeResponseDto {
     private String content;
     private Boolean isPinned;
     private LocalDateTime createdAt;
+    private List<String> imageUrls;
 
     public NoticeResponseDto(Notice notice) {
         this.id = notice.getId();
@@ -19,5 +21,6 @@ public class NoticeResponseDto {
         this.content = notice.getContent();
         this.isPinned = notice.isPinned();
         this.createdAt = notice.getCreatedAt();
+        this.imageUrls = notice.getImageUrls();
     }
 }

--- a/src/main/java/cotw/server/domain/board/entity/Notice.java
+++ b/src/main/java/cotw/server/domain/board/entity/Notice.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -27,6 +30,12 @@ public class Notice extends BaseEntity {
     @Column(nullable = false)
     private boolean isPinned; // 상단 고정 여부
 
+    // 이미지 URL 리스트
+    @ElementCollection
+    @CollectionTable(name = "notice_images", joinColumns = @JoinColumn(name = "notice_id"))
+    @Column(name = "image_url")
+    private List<String> imageUrls = new ArrayList<>();
+
     public void update(NoticeRequestDto dto) {
         if (dto.getTitle() != null) {
             this.title = dto.getTitle();
@@ -36,6 +45,10 @@ public class Notice extends BaseEntity {
         }
         if (dto.getIsPinned() != null) {
             this.isPinned = dto.getIsPinned();
+        }
+        if (dto.getImageUrls() != null) {
+            this.imageUrls.clear();
+            this.imageUrls.addAll(dto.getImageUrls());
         }
     }
 }

--- a/src/main/java/cotw/server/domain/board/service/NoticeService.java
+++ b/src/main/java/cotw/server/domain/board/service/NoticeService.java
@@ -1,14 +1,20 @@
 package cotw.server.domain.board.service;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import cotw.server.domain.board.dto.request.NoticeRequestDto;
 import cotw.server.domain.board.dto.response.NoticeResponseDto;
 import cotw.server.domain.board.entity.Notice;
 import cotw.server.domain.board.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,6 +27,7 @@ public class NoticeService {
                 .title(dto.getTitle())
                 .content(dto.getContent())
                 .isPinned(dto.getIsPinned())
+                .imageUrls(dto.getImageUrls() != null ? dto.getImageUrls() : List.of())
                 .build();
         return new NoticeResponseDto(noticeRepository.save(notice));
     }

--- a/src/main/java/cotw/server/domain/board/service/PostService.java
+++ b/src/main/java/cotw/server/domain/board/service/PostService.java
@@ -60,7 +60,9 @@ public class PostService {
         // 엔티티 생성 및 이미지 바인딩
         Post post = dto.toPostEntity(author);
         List<Image> images = dto.toImageEntityList(post);
-        images.forEach(post::addImage);
+        if (images != null && !images.isEmpty()) {
+            images.forEach(post::addImage);
+        }
 
         // DB 저장
         postRepository.save(post);
@@ -154,13 +156,13 @@ public class PostService {
         // 1) 기존 이미지 삭제
         post.clearImages();
 
-        // 2) 새 이미지 등록
+        // 2) 새 이미지가 있는 경우에만 등록
         if (dto.getImageUrls() != null && !dto.getImageUrls().isEmpty()) {
             for (int i = 0; i < dto.getImageUrls().size(); i++) {
                 Image img = Image.builder()
                         .post(post)
                         .imageUrl(dto.getImageUrls().get(i))
-                        .isThumbnail(i == 0)   // 첫 번째 이미지를 썸네일로
+                        .isThumbnail(i == 0)
                         .orderIndex(i)
                         .build();
                 post.addImage(img);
@@ -174,19 +176,18 @@ public class PostService {
      * - isPublic = true → 공개, false → 비공개
      */
     @Transactional
-    public void changePostVisibility(Long postId, boolean isPublic, String requesterEmail) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
-
+    public void changePostsVisibility(List<Long> postIds, boolean isPublic, String requesterEmail) {
         Member requester = memberRepository.findByEmail(requesterEmail)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
-        // 권한 검증 (관리자만)
-        if (!requester.getRole().equals(Role.ADMIN)) {
+        if (requester.getRole() != Role.ADMIN) {
             throw new AccessDeniedException("관리자만 변경 가능합니다.");
         }
 
-        post.changeVisibility(isPublic);
+        List<Post> posts = postRepository.findAllById(postIds);
+        for (Post post : posts) {
+            post.changeVisibility(isPublic);
+        }
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#35 
## ✅ 작업 내용
- 공지사항에 이미지 업로드 기능 추가
- 게시글 이미지가 없어도 등록 가능하도록 수정
- 관리자가 is_public=false 게시글을 조회 후 true(공개)로 변경할 수 있도록 기능 추가
## 리뷰 요구사항 (선택)

## 기타 (선택)