### PR TITLE
Fix/comment

### DIFF
--- a/src/main/java/cotw/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/cotw/server/domain/comment/controller/CommentController.java
@@ -7,7 +7,9 @@ import cotw.server.domain.comment.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -34,16 +36,27 @@ public class CommentController {
     @GetMapping
     public ResponseEntity<Page<CommentResponse>> list(
             @RequestParam Long postId,
-            @AuthenticationPrincipal(expression = "id") Long viewerId,
+            @AuthenticationPrincipal cotw.server.common.jwt.CustomUserDetails principal,
             Authentication authentication,
             @RequestParam(defaultValue = "LATEST") String sort,
-            @PageableDefault(size = 20) Pageable pageable
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
+        Long viewerId = (principal != null) ? principal.getId() : null;
         boolean admin = isAdmin(authentication);
-        Page<CommentResponse> page = "LIKE".equalsIgnoreCase(sort)
-                ? commentService.listByLike(postId, viewerId, admin, pageable)
-                : commentService.listLatest(postId, viewerId, admin, pageable);
-        return ResponseEntity.ok(page);
+
+        Page<CommentResponse> pageResult;
+        if ("LIKE".equalsIgnoreCase(sort)) {
+            // 좋아요순 (likeCount desc, id desc)
+            Pageable realPageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("likeCount"), Sort.Order.desc("id")));
+            pageResult = commentService.listByLike(postId, viewerId, admin, realPageable);
+        } else {
+            // 최신순 (createdAt desc, id desc)
+            Pageable realPageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id")));
+            pageResult = commentService.listLatest(postId, viewerId, admin, realPageable);
+        }
+
+        return ResponseEntity.ok(pageResult);
     }
 
     /** 댓글 수정(본인만) */

--- a/src/main/java/cotw/server/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/cotw/server/domain/comment/dto/response/CommentResponse.java
@@ -12,5 +12,6 @@ public record CommentResponse(
         boolean isPublic,
         LocalDateTime createdAt,
         LocalDateTime moderationDueAt,
-        boolean liked
+        boolean liked,
+        String authorEmail
 ) {}

--- a/src/main/java/cotw/server/domain/comment/entity/CommentLike.java
+++ b/src/main/java/cotw/server/domain/comment/entity/CommentLike.java
@@ -1,6 +1,6 @@
 package cotw.server.domain.comment.entity;
 
-import cotw.server.common.BaseEntity;   // ✅ BaseEntity import
+import cotw.server.common.BaseEntity;
 import cotw.server.domain.member.entity.Member;
 import cotw.server.domain.board.entity.Comment;
 import jakarta.persistence.*;
@@ -9,28 +9,44 @@ import lombok.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
-@Table(name = "comment_like",
-        uniqueConstraints = @UniqueConstraint(name = "uq_comment_like",
-                columnNames = {"comment_id", "member_id"}),
+@Table(
+        name = "comment_like",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_comment_like_comment_member",
+                columnNames = {"comment_id", "member_id"}
+        ),
         indexes = {
                 @Index(name = "idx_like_comment", columnList = "comment_id"),
                 @Index(name = "idx_like_member", columnList = "member_id")
-        })
-@Getter @Setter
+        }
+)
+@Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor @Builder
-public class CommentLike extends BaseEntity {   // ✅ 공통 엔티티 상속
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"comment", "member"})
+@EqualsAndHashCode(of = "id")
+public class CommentLike extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "comment_like_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "comment_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_comment_like_comment")
+    )
     private Comment comment;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "member_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_comment_like_member")
+    )
     private Member member;
-
-
 }

--- a/src/main/java/cotw/server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/cotw/server/domain/comment/repository/CommentRepository.java
@@ -82,12 +82,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
                                   Pageable pageable);
 
     // ===== 비정규화 카운터: 원자적 증가/감소 =====
-    // flush 즉시 수행 + 1차 캐시 자동 클리어로 stale 방지
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    // flush만 자동, clear는 비활성화하여 관리 상태 유지
+    @Modifying(flushAutomatically = true)
     @Query("update Comment c set c.likeCount = c.likeCount + 1 where c.id = :commentId")
     int incrementLikeCount(@Param("commentId") Long commentId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("""
         update Comment c
            set c.likeCount = case when c.likeCount > 0 then c.likeCount - 1 else 0 end
@@ -97,11 +97,11 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 
     // ====== 관리자 전용 조회 ======
-// 상태 정의
-// PENDING : 숨김 & 삭제 아님 & 검토기한 >= now
-// EXPIRED : 숨김 & 삭제 아님 & 검토기한  < now
-// HIDDEN  : 숨김(삭제 포함) 전체
-// ALL     : 신고 관련 모든 것 (reportCount>0 or 숨김 or 검토기한 설정됨)
+    // 상태 정의
+    // PENDING : 숨김 & 삭제 아님 & 검토기한 >= now
+    // EXPIRED : 숨김 & 삭제 아님 & 검토기한  < now
+    // HIDDEN  : 숨김(삭제 포함) 전체
+    // ALL     : 신고 관련 모든 것 (reportCount>0 or 숨김 or 검토기한 설정됨)
 
     @Query(value = """
     select c from Comment c

--- a/src/main/java/cotw/server/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/cotw/server/domain/comment/service/CommentLikeService.java
@@ -25,27 +25,28 @@ public class CommentLikeService {
     private final EntityManager em;
 
     public LikeResponse like(Long commentId, LikeRequest req) {
-        Comment c = get(commentId);
+        // 관리 상태 보장 (없으면 404)
+        Comment c = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("comment not found: " + commentId));
 
         try {
-            // UNIQUE(comment_id, member_id) 제약으로 중복 좋아요는 여기서 예외 발생
+            // UNIQUE(comment_id, member_id) 제약으로 중복 좋아요 시 예외 발생
             likeRepository.save(CommentLike.builder()
-                    .comment(c)
+                    .comment(c) // 이미 관리 상태
                     .member(em.getReference(Member.class, req.memberId()))
                     .build());
 
-            // 실제 삽입된 경우에만 원자적 증가
+            // 실제 삽입된 경우만 증가
             commentRepository.incrementLikeCount(commentId);
 
-            // 최신 카운트를 정확히 주고 싶으면 flush+refresh
+            // 최신 카운트 보장
             em.flush();
             em.refresh(c);
 
             return new LikeResponse(commentId, c.getLikeCount(), true);
 
         } catch (DataIntegrityViolationException e) {
-            // 이미 좋아요 상태(멱등)
-            // 최신값 보장을 위해 refresh 시도(필수는 아님)
+            // 이미 좋아요(멱등)
             em.flush();
             em.refresh(c);
             return new LikeResponse(commentId, c.getLikeCount(), true);
@@ -53,24 +54,17 @@ public class CommentLikeService {
     }
 
     public LikeResponse unlike(Long commentId, Long memberId) {
-        Comment c = get(commentId);
+        // 관리 상태 보장 (없으면 404)
+        Comment c = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("comment not found: " + commentId));
 
         long deleted = likeRepository.deleteByCommentIdAndMemberId(commentId, memberId);
         if (deleted > 0) {
             commentRepository.decrementLikeCount(commentId);
-            em.flush();
-            em.refresh(c);
-            return new LikeResponse(commentId, c.getLikeCount(), false);
-        } else {
-            // 이미 좋아요가 없는 상태(멱등)
-            em.flush();
-            em.refresh(c);
-            return new LikeResponse(commentId, c.getLikeCount(), false);
         }
-    }
 
-    private Comment get(Long id) {
-        return commentRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("comment not found: " + id));
+        em.flush();
+        em.refresh(c);
+        return new LikeResponse(commentId, c.getLikeCount(), false);
     }
 }

--- a/src/main/java/cotw/server/domain/comment/service/CommentReportService.java
+++ b/src/main/java/cotw/server/domain/comment/service/CommentReportService.java
@@ -1,3 +1,4 @@
+// src/main/java/cotw/server/domain/comment/service/CommentReportService.java
 package cotw.server.domain.comment.service;
 
 import cotw.server.domain.board.entity.Comment;
@@ -18,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -31,7 +31,7 @@ public class CommentReportService {
     private final EntityManager em;
 
     public ReportResponse report(Long reporterId, Long commentId, ReportRequest req) {
-        // 1) 하루 신고 3회 제한 ([start, end)로 집계)
+        // 1) 하루 신고 3회 제한
         LocalDate today = LocalDate.now();
         LocalDateTime start = today.atStartOfDay();
         LocalDateTime end = today.plusDays(1).atStartOfDay();
@@ -39,53 +39,53 @@ public class CommentReportService {
             throw new IllegalStateException("하루 신고 한도(3회)를 초과했습니다.");
         }
 
-        // 2) ETC면 detail 필수
+        // 2) 기타 사유면 상세 필수
         if (req.reason() == ReportReason.ETC &&
                 (req.detail() == null || req.detail().isBlank())) {
             throw new IllegalStateException("기타 사유를 선택한 경우 상세 내용을 입력해주세요.");
         }
 
-        // 3) 신고 대상 댓글 로딩 및 검증
+        // 3) 대상 댓글 검증
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다: " + commentId));
         if (comment.isDeleted()) {
             throw new IllegalStateException("삭제된 댓글은 신고할 수 없습니다.");
         }
-        if (!comment.isPublic()) { // 숨김 처리된 댓글 신고 금지(정책)
+        if (!comment.isPublic()) {
             throw new IllegalStateException("이미 숨겨진 댓글은 신고할 수 없습니다.");
         }
-        if (comment.getMember().getId().equals(reporterId)) { // 본인 댓글 신고 금지(정책)
+        if (comment.getMember().getId().equals(reporterId)) {
             throw new IllegalStateException("본인 댓글은 신고할 수 없습니다.");
         }
 
-        // 프록시 참조(성능): 신고자 엔티티 전체 로딩 대신 프록시로 연관관계 세팅
-        Member reporterRef = em.getReference(Member.class, reporterId);
-
-        // 4) 신고 저장(UNIQUE 제약으로 중복 레이스 방어)
+        // 4) 신고 저장 (UNIQUE 제약으로 중복 방지)
         String detail = (req.detail() == null || req.detail().isBlank()) ? null : req.detail().trim();
         try {
             reportRepository.save(CommentReport.builder()
-                    .comment(comment)
-                    .member(reporterRef)
+                    .comment(comment) // 관리 상태 엔티티
+                    .member(em.getReference(Member.class, reporterId))
                     .reason(req.reason())
                     .detail(detail)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            // 동시에 같은 사용자가 같은 댓글을 두 번 누른 경우 등
             throw new IllegalStateException("이미 신고한 댓글입니다.");
         }
 
-        // 5) 저장 후 총 신고 수 재계산 → 엔티티 규칙으로 일관 반영
+        // 5) 총 신고 수 재계산 및 규칙 반영
         int total = (int) reportRepository.countByCommentId(commentId);
         comment.applyReportTally(total);
 
-        // 6) 응답(현재 상태 스냅샷)
+        // 최신 스냅샷 보장
+        em.flush();
+        em.refresh(comment);
+
+        // 6) 응답
         return new ReportResponse(
                 commentId,
                 reporterId,
                 req.reason(),
                 comment.getReportCount(),
-                !comment.isPublic(),            // hidden = !isPublic
+                !comment.isPublic(),
                 comment.getModerationDueAt()
         );
     }

--- a/src/main/java/cotw/server/domain/comment/service/CommentService.java
+++ b/src/main/java/cotw/server/domain/comment/service/CommentService.java
@@ -87,11 +87,12 @@ public class CommentService {
     }
     // 기존 toRes 수정: 작성/수정 직후엔 liked=false로 고정(필요 시 오버로드 사용)
     private CommentResponse toRes(Comment c) {
+        String email = c.getMember().getEmail();
         return new CommentResponse(
                 c.getId(), c.getPost().getId(), c.getMember().getId(),
                 c.getContent(), c.getLikeCount(), c.getReportCount(), c.isPublic(),
                 c.getCreatedAt(), c.getModerationDueAt(),
-                false // ✅ 기본값
+                false, email
         );
     }
 
@@ -100,11 +101,16 @@ public class CommentService {
         boolean liked = (viewerId != null)
                 && likeRepository.existsByCommentIdAndMemberId(c.getId(), viewerId);
 
+        String email = c.getMember().getEmail();
+
         return new CommentResponse(
+
                 c.getId(), c.getPost().getId(), c.getMember().getId(),
                 c.getContent(), c.getLikeCount(), c.getReportCount(), c.isPublic(),
                 c.getCreatedAt(), c.getModerationDueAt(),
-                liked // ✅ 계산된 값
+                liked,
+                email
+
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✅ 작업 내용
- CommentResponse DTO에 `authorEmail` 필드 추가
- CommentService → toRes() 매핑 시 authorEmail 포함하도록 수정
- CommentLikeService: 중복 좋아요 멱등 처리 및 unlike 로직 단순화
- CommentReportService: 신고 처리 시 flush/refresh 추가, 최신 카운트 보장
- CommentRepository: likeCount 증감 메서드 clearAutomatically 제거 → 영속성 컨텍스트 유지
- CommentController: 페이지네이션/정렬 로직 명시적 PageRequest 기반으로 개선
## 리뷰 요구사항 (선택)

## 기타 (선택)