### PR TITLE
feat/admin: 관리자 대시보드 API 및 기능 추가

### DIFF
--- a/src/main/java/cotw/server/domain/admin/controller/AdminDashboardController.java
+++ b/src/main/java/cotw/server/domain/admin/controller/AdminDashboardController.java
@@ -1,0 +1,31 @@
+package cotw.server.domain.admin.controller;
+
+import cotw.server.domain.admin.dto.response.AdminDashboardResponse;
+import cotw.server.domain.admin.service.AdminDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/admin/dashboard")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminDashboardController {
+
+    private final AdminDashboardService service;
+
+    @GetMapping
+    public ResponseEntity<AdminDashboardResponse> dashboard(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end
+    ) {
+        return ResponseEntity.ok(service.getDashboard(start, end));
+    }
+}

--- a/src/main/java/cotw/server/domain/admin/controller/AdminMemberController.java
+++ b/src/main/java/cotw/server/domain/admin/controller/AdminMemberController.java
@@ -1,0 +1,66 @@
+package cotw.server.domain.admin.controller;
+
+import cotw.server.domain.admin.dto.request.*;
+import cotw.server.domain.admin.dto.response.*;
+import cotw.server.domain.admin.service.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/members")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminMemberController {
+
+    private final AdminMemberService service;
+
+    @GetMapping
+    public ResponseEntity<AdminMemberListResponse> list(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String role,
+            @RequestParam(required = false) String status
+    ) {
+        return ResponseEntity.ok(service.search(keyword, role, status, page, size));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AdminMemberDetailResponse> get(@PathVariable Long id) {
+        return ResponseEntity.ok(service.get(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable Long id,
+                                       @RequestBody AdminMemberProfileRequest req) {
+        service.updateProfile(id, req);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{id}/roles")
+    public ResponseEntity<Void> updateRole(@PathVariable Long id,
+                                           @RequestBody AdminMemberRoleRequest req) {
+        service.updateRole(id, req);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/bulk-delete")
+    public ResponseEntity<Void> bulkDelete(@RequestBody IdListRequest req) {
+        service.bulkDelete(req.ids());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/bulk-status")
+    public ResponseEntity<Void> bulkStatus(@RequestBody AdminMemberBulkStatusRequest req) {
+        service.bulkUpdateStatus(req.ids(), req.status());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberBulkStatusRequest.java
+++ b/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberBulkStatusRequest.java
@@ -1,0 +1,9 @@
+package cotw.server.domain.admin.dto.request;
+
+import cotw.server.domain.member.entity.AccountStatus;
+import java.util.List;
+
+public record AdminMemberBulkStatusRequest(
+        List<Long> ids,
+        AccountStatus status
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberProfileRequest.java
+++ b/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberProfileRequest.java
@@ -1,0 +1,9 @@
+package cotw.server.domain.admin.dto.request;
+
+import cotw.server.domain.member.entity.AccountStatus;
+
+public record AdminMemberProfileRequest(
+        String name,
+        String email,
+        AccountStatus status
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberRoleRequest.java
+++ b/src/main/java/cotw/server/domain/admin/dto/request/AdminMemberRoleRequest.java
@@ -1,0 +1,5 @@
+package cotw.server.domain.admin.dto.request;
+
+public record AdminMemberRoleRequest(
+        String role
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminDailyDonationResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminDailyDonationResponse.java
@@ -1,0 +1,8 @@
+package cotw.server.domain.admin.dto.response;
+
+import java.util.List;
+
+public record AdminDailyDonationResponse(
+        List<String> labels,
+        List<Long> values
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminDashboardKpiResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminDashboardKpiResponse.java
@@ -1,0 +1,11 @@
+
+package cotw.server.domain.admin.dto.response;
+
+public record AdminDashboardKpiResponse(
+        long todayDonation,
+        long totalDonation,
+        long newUsers,
+        long totalUsers,
+        long pendingReports,
+        long dueIn48h
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminDashboardResponse.java
@@ -1,0 +1,10 @@
+package cotw.server.domain.admin.dto.response;
+
+import java.util.List;
+
+public record AdminDashboardResponse(
+        AdminDashboardKpiResponse kpi,
+        List<AdminRecentPaymentResponse> recentPayments,
+        List<AdminRecentReportResponse> recentReports,
+        AdminDailyDonationResponse dailyDonation
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberDetailResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberDetailResponse.java
@@ -1,0 +1,12 @@
+package cotw.server.domain.admin.dto.response;
+
+import cotw.server.domain.member.entity.AccountStatus;
+import java.util.List;
+
+public record AdminMemberDetailResponse(
+        long id,
+        String name,
+        String email,
+        AccountStatus status,
+        List<String> roles
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberListItemResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberListItemResponse.java
@@ -1,0 +1,14 @@
+package cotw.server.domain.admin.dto.response;
+
+import cotw.server.domain.member.entity.AccountStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminMemberListItemResponse(
+        long id,
+        String name,
+        String email,
+        List<String> roles,
+        AccountStatus status,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberListResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminMemberListResponse.java
@@ -1,0 +1,8 @@
+package cotw.server.domain.admin.dto.response;
+
+import java.util.List;
+
+public record AdminMemberListResponse(
+        List<AdminMemberListItemResponse> content,
+        long totalElements
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminRecentPaymentResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminRecentPaymentResponse.java
@@ -1,0 +1,10 @@
+package cotw.server.domain.admin.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AdminRecentPaymentResponse(
+        String donorEmail,
+        long amount,
+        String status,
+        LocalDateTime at
+) {}

--- a/src/main/java/cotw/server/domain/admin/dto/response/AdminRecentReportResponse.java
+++ b/src/main/java/cotw/server/domain/admin/dto/response/AdminRecentReportResponse.java
@@ -1,0 +1,10 @@
+package cotw.server.domain.admin.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AdminRecentReportResponse(
+        String reportedMemberEmail,
+        String reason,
+        long count,
+        LocalDateTime at
+) {}

--- a/src/main/java/cotw/server/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/cotw/server/domain/admin/service/AdminDashboardService.java
@@ -97,9 +97,7 @@ public class AdminDashboardService {
         // 일간 기부액 추이
         Map<LocalDate, Long> dailyMap = new HashMap<>();
         for (Object[] row : paymentOrderRepository.sumDailyBetween(from, to)) {
-            LocalDate day = (row[0] instanceof LocalDate)
-                    ? (LocalDate) row[0]
-                    : ((java.sql.Date) row[0]).toLocalDate();
+            LocalDate day = ((java.sql.Date) row[0]).toLocalDate(); // ✅ 항상 java.sql.Date로 변환
             dailyMap.put(day, ((Number) row[1]).longValue());
         }
         List<String> labels = new ArrayList<>();

--- a/src/main/java/cotw/server/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/cotw/server/domain/admin/service/AdminDashboardService.java
@@ -1,0 +1,117 @@
+package cotw.server.domain.admin.service;
+
+import cotw.server.domain.admin.dto.response.*;
+import cotw.server.domain.comment.repository.CommentReportRepository;
+import cotw.server.domain.comment.repository.CommentRepository;
+import cotw.server.domain.member.repository.MemberRepository;
+import cotw.server.domain.payment.entity.PaymentStatus;
+import cotw.server.domain.payment.repository.PaymentOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminDashboardService {
+
+    private final PaymentOrderRepository paymentOrderRepository;
+    private final CommentReportRepository commentReportRepository;
+    private final CommentRepository commentRepository;   // ✅ 댓글 기준 집계
+    private final MemberRepository memberRepository;
+
+    public AdminDashboardResponse getDashboard(LocalDate start, LocalDate end) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
+        LocalDateTime todayEnd = today.plusDays(1).atStartOfDay();
+
+        LocalDate s = (start != null) ? start : today.withDayOfMonth(1);
+        LocalDate e = (end != null) ? end : today;
+        LocalDateTime from = s.atStartOfDay();
+        LocalDateTime to = e.plusDays(1).atStartOfDay();
+
+        // ✅ KPI 계산
+        long todayDonation = paymentOrderRepository.sumDoneBetween(todayStart, todayEnd);
+        long totalDonation = paymentOrderRepository.sumDoneBetween(from, to);
+
+        long newUsers = memberRepository.countByCreatedAtBetween(todayStart, todayEnd);
+        long totalUsers = memberRepository.countActiveMembers();
+
+        // ✅ 미처리 신고 = 신고당한 댓글 수
+        long pendingReports = commentRepository.countReportedComments();
+
+        // ✅ 48시간 내 처리 대상 = 블라인드 처리된 댓글 수
+        long dueIn48h = commentRepository.countDueIn48h(LocalDateTime.now().plusHours(48));
+
+        var kpi = new AdminDashboardKpiResponse(
+                todayDonation,
+                totalDonation,
+                newUsers,
+                totalUsers,
+                pendingReports,
+                dueIn48h
+        );
+
+        // 최근 기부내역 5건 → 이메일 내려주기
+        List<AdminRecentPaymentResponse> recentPayments = paymentOrderRepository
+                .findTop5ByStatusOrderByCreatedAtDesc(PaymentStatus.DONE)
+                .stream()
+                .map(po -> new AdminRecentPaymentResponse(
+                        po.getMember().getEmail(),   // ✅ 이메일
+                        po.getAmount(),
+                        po.getStatus().name(),
+                        po.getCreatedAt()
+                ))
+                .toList();
+
+        // 최근 신고 댓글 5건 → 댓글 작성자 이메일 내려주기
+        List<Object[]> recent = commentReportRepository.findRecentCommentIds(PageRequest.of(0, 5));
+        List<AdminRecentReportResponse> recentReports = recent.stream().map(r -> {
+            Long commentId = (Long) r[0];
+            LocalDateTime lastAt = (LocalDateTime) r[1];
+            long count = commentReportRepository.countActiveByCommentId(commentId);
+
+            String top = null;
+            int max = -1;
+            for (Object[] row : commentReportRepository.countActiveByReason(commentId)) {
+                String reason = String.valueOf(row[0]);
+                int c = ((Number) row[1]).intValue();
+                if (c > max) { max = c; top = reason; }
+            }
+
+            // ✅ 댓글 작성자 이메일 가져오기
+            String reportedMemberEmail = commentReportRepository
+                    .findFirstByCommentIdOrderByCreatedAtAsc(commentId)
+                    .getComment()
+                    .getMember()
+                    .getEmail();
+
+            return new AdminRecentReportResponse(reportedMemberEmail, top, count, lastAt);
+        }).toList();
+
+        // 일간 기부액 추이
+        Map<LocalDate, Long> dailyMap = new HashMap<>();
+        for (Object[] row : paymentOrderRepository.sumDailyBetween(from, to)) {
+            LocalDate day = (row[0] instanceof LocalDate)
+                    ? (LocalDate) row[0]
+                    : ((java.sql.Date) row[0]).toLocalDate();
+            dailyMap.put(day, ((Number) row[1]).longValue());
+        }
+        List<String> labels = new ArrayList<>();
+        List<Long> values = new ArrayList<>();
+        LocalDate cursor = s;
+        while (!cursor.isAfter(e)) {
+            labels.add(cursor.toString());
+            values.add(dailyMap.getOrDefault(cursor, 0L));
+            cursor = cursor.plusDays(1);
+        }
+        var daily = new AdminDailyDonationResponse(labels, values);
+
+        return new AdminDashboardResponse(kpi, recentPayments, recentReports, daily);
+    }
+}

--- a/src/main/java/cotw/server/domain/admin/service/AdminMemberService.java
+++ b/src/main/java/cotw/server/domain/admin/service/AdminMemberService.java
@@ -1,0 +1,111 @@
+package cotw.server.domain.admin.service;
+
+import cotw.server.domain.admin.dto.request.*;
+import cotw.server.domain.admin.dto.response.*;
+import cotw.server.domain.member.entity.AccountStatus;
+import cotw.server.domain.member.entity.Member;
+import cotw.server.domain.member.entity.Role;
+import cotw.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public AdminMemberListResponse search(String keyword, String role, String status, int page, int size) {
+        String kw = (keyword != null && !keyword.isBlank()) ? "%" + keyword.trim().toLowerCase() + "%" : null;
+        Role r = parseRole(role);
+        AccountStatus st = parseStatus(status);
+        Page<Member> result = memberRepository.searchMembers(kw, r, st, PageRequest.of(page - 1, size));
+        List<AdminMemberListItemResponse> content = result.getContent().stream()
+                .map(m -> new AdminMemberListItemResponse(
+                        m.getId(),
+                        m.getName(),
+                        m.getEmail(),
+                        List.of(m.getRole().getAuthority()),
+                        m.getStatus(),
+                        m.getCreatedAt()))
+                .toList();
+        return new AdminMemberListResponse(content, result.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminMemberDetailResponse get(Long id) {
+        Member m = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+        return new AdminMemberDetailResponse(
+                m.getId(),
+                m.getName(),
+                m.getEmail(),
+                m.getStatus(),
+                List.of(m.getRole().getAuthority())
+        );
+    }
+
+    public void updateProfile(Long id, AdminMemberProfileRequest req) {
+        Member m = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+        Optional.ofNullable(req.name()).ifPresent(m::setName);
+        Optional.ofNullable(req.email()).ifPresent(e -> m.setEmail(e.toLowerCase()));
+        Optional.ofNullable(req.status()).ifPresent(m::setStatus);
+    }
+
+    public void updateRole(Long id, AdminMemberRoleRequest req) {
+        Member m = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+        Role r = parseRole(req.role());
+        if (r != null) {
+            m.setRole(r);
+        }
+    }
+
+    public void delete(Long id) {
+        Member m = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+        m.setStatus(AccountStatus.DELETED);
+        m.setDeletedAt(LocalDateTime.now());
+    }
+
+    public void bulkDelete(List<Long> ids) {
+        ids.forEach(this::delete);
+    }
+
+    public void bulkUpdateStatus(List<Long> ids, AccountStatus status) {
+        for (Long id : ids) {
+            Member m = memberRepository.findById(id)
+                    .orElseThrow(() -> new IllegalArgumentException("member not found"));
+            m.setStatus(status);
+        }
+    }
+
+    private Role parseRole(String role) {
+        if (role == null || role.isBlank()) return null;
+        String r = role.startsWith("ROLE_") ? role.substring(5) : role;
+        try {
+            return Role.valueOf(r);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private AccountStatus parseStatus(String status) {
+        if (status == null || status.isBlank()) return null;
+        try {
+            return AccountStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/cotw/server/domain/comment/repository/CommentReportRepository.java
+++ b/src/main/java/cotw/server/domain/comment/repository/CommentReportRepository.java
@@ -1,6 +1,7 @@
 package cotw.server.domain.comment.repository;
 
 import cotw.server.domain.comment.entity.CommentReport;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
@@ -11,10 +12,8 @@ import java.util.Optional;
 
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
-    // 동일 댓글/사용자 신고 여부 (중복 신고 방지)
     boolean existsByCommentIdAndMemberId(Long commentId, Long memberId);
 
-    // 하루 신고 횟수 집계 ([start, end), clearedAt 무시 → 일일 제한 용도)
     @Query("""
        select count(r) from CommentReport r
         where r.member.id = :memberId
@@ -24,7 +23,6 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
                             @Param("start") LocalDateTime start,
                             @Param("end") LocalDateTime end);
 
-    // ===== 활성 신고 집계 (clearedAt is null) =====
     @Query("select count(r) from CommentReport r where r.comment.id = :commentId and r.clearedAt is null")
     long countActiveByCommentId(@Param("commentId") Long commentId);
 
@@ -36,8 +34,6 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
     """)
     List<Object[]> countActiveByReason(@Param("commentId") Long commentId);
 
-    // ===== 활성 로그 조회 (확장행용) =====
-
     @EntityGraph(attributePaths = {"member"})
     List<CommentReport> findByCommentIdAndClearedAtIsNullOrderByCreatedAtDesc(Long commentId);
 
@@ -46,17 +42,22 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
     @Query("select r.reason, count(r) from CommentReport r where r.comment.id = :commentId group by r.reason")
     List<Object[]> countByReason(@Param("commentId") Long commentId);
 
-    // (선택) 활성 로그의 마지막 신고 시각
     @Query("select max(r.createdAt) from CommentReport r where r.comment.id = :commentId and r.clearedAt is null")
     Optional<LocalDateTime> findLastActiveReportedAt(@Param("commentId") Long commentId);
 
-    // 기간 카운트 (대시보드용)
     long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
-    // 최초 신고 (전체 로그 기준)
+    @Query("""
+        select r.comment.id, max(r.createdAt)
+          from CommentReport r
+         where r.clearedAt is null
+         group by r.comment.id
+         order by max(r.createdAt) desc
+    """)
+    List<Object[]> findRecentCommentIds(Pageable pageable);
+
     CommentReport findFirstByCommentIdOrderByCreatedAtAsc(Long commentId);
 
-    // ===== 신고 초기화: '무효 처리' (clearedAt 업데이트) =====
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update CommentReport r set r.clearedAt = CURRENT_TIMESTAMP where r.comment.id = :commentId and r.clearedAt is null")
     int clearByCommentId(@Param("commentId") Long commentId);
@@ -65,7 +66,6 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
     @Query("update CommentReport r set r.clearedAt = CURRENT_TIMESTAMP where r.comment.id in :ids and r.clearedAt is null")
     int clearByCommentIdIn(@Param("ids") List<Long> ids);
 
-    // ===== (선택) 하드 삭제 (정말 필요할 때만 사용) =====
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from CommentReport r where r.comment.id = :commentId")
     void hardDeleteByCommentId(@Param("commentId") Long commentId);
@@ -74,4 +74,7 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
     @Query("delete from CommentReport r where r.comment.id in :ids")
     void hardDeleteByCommentIdIn(@Param("ids") List<Long> ids);
 
+    // ✅ 미처리 신고 전체 개수
+    @Query("select count(r) from CommentReport r where r.clearedAt is null")
+    long countByClearedAtIsNull();
 }

--- a/src/main/java/cotw/server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/cotw/server/domain/comment/repository/CommentRepository.java
@@ -377,4 +377,28 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, JpaSpec
            and c.deletedAt is null
     """)
     long countAdminReported();
+
+    @Query("""
+    select count(c)
+    from Comment c
+    where c.isPublic = false
+      and c.deletedAt is null
+      and c.moderationDueAt is not null
+      and c.moderationDueAt <= :dueAt
+""")
+    long countDueIn48h(@Param("dueAt") java.time.LocalDateTime dueAt);
+
+
+    @Query("""
+    select count(distinct c.id)
+    from Comment c
+    where c.deletedAt is null
+      and exists (
+          select 1
+          from CommentReport r
+          where r.comment.id = c.id
+            and r.clearedAt is null
+      )
+""")
+    long countReportedComments();
 }

--- a/src/main/java/cotw/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/cotw/server/domain/member/repository/MemberRepository.java
@@ -37,6 +37,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findEmailById(Long id);
 
+    long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
     @Query("select m.id as id, m.email as email from Member m where m.id in :ids")
     List<MemberEmailProjection> findEmailsByIdIn(@Param("ids") List<Long> ids);
 
@@ -63,4 +65,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                                @Param("role") Role role,
                                @Param("status") AccountStatus status,
                                Pageable pageable);
+
+    // ✅ 전체 회원 수 (탈퇴 회원 제외)
+    @Query("select count(m) from Member m where m.status <> cotw.server.domain.member.entity.AccountStatus.DELETED")
+    long countActiveMembers();
 }

--- a/src/main/java/cotw/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/cotw/server/domain/member/repository/MemberRepository.java
@@ -2,6 +2,9 @@ package cotw.server.domain.member.repository;
 
 import cotw.server.domain.member.entity.Member;
 import cotw.server.domain.member.entity.ProviderType;
+import cotw.server.domain.member.entity.AccountStatus;
+import cotw.server.domain.member.entity.Role;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -36,4 +39,28 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m.id as id, m.email as email from Member m where m.id in :ids")
     List<MemberEmailProjection> findEmailsByIdIn(@Param("ids") List<Long> ids);
+
+    @Query(value = """
+        select m from Member m
+        where m.status <> cotw.server.domain.member.entity.AccountStatus.DELETED
+          and ((:keyword is null or :keyword = '') 
+               or lower(m.name) like :keyword 
+               or lower(m.email) like :keyword)
+          and (:role is null or m.role = :role)
+          and (:status is null or m.status = :status)
+        order by m.createdAt desc, m.id desc
+    """,
+            countQuery = """
+        select count(m) from Member m
+        where m.status <> cotw.server.domain.member.entity.AccountStatus.DELETED
+          and ((:keyword is null or :keyword = '') 
+               or lower(m.name) like :keyword 
+               or lower(m.email) like :keyword)
+          and (:role is null or m.role = :role)
+          and (:status is null or m.status = :status)
+    """)
+    Page<Member> searchMembers(@Param("keyword") String keyword,
+                               @Param("role") Role role,
+                               @Param("status") AccountStatus status,
+                               Pageable pageable);
 }

--- a/src/main/java/cotw/server/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/cotw/server/domain/payment/repository/PaymentOrderRepository.java
@@ -24,10 +24,15 @@ import java.util.Optional;
 public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
 
     Optional<PaymentOrder> findByOrderId(String orderId);
+
     Optional<PaymentOrder> findByPaymentKey(String paymentKey);
+
     List<PaymentOrder> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
     List<PaymentOrder> findByPostIdOrderByCreatedAtDesc(Long postId);
+
     boolean existsByOrderId(String orderId);
+
     boolean existsByPostId(Long postId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -120,6 +125,7 @@ public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long
     Page<AdminDonationListItemResponse> searchDonations(@Param("search") String search,
                                                         @Param("status") PaymentStatus status,
                                                         Pageable pageable);
+
     // ===== 대시보드: 기간별 집계 =====
 
     @Query("""
@@ -151,13 +157,14 @@ public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long
                                             @Param("start") LocalDateTime start,
                                             @Param("end") LocalDateTime end);
 
+
     @Query("""
-        select function('date', po.createdAt) as day, sum(po.amount)
+        select cast(po.createdAt as date), sum(po.amount)
           from PaymentOrder po
          where po.status = cotw.server.domain.payment.entity.PaymentStatus.DONE
            and po.createdAt >= :start and po.createdAt < :end
-         group by function('date', po.createdAt)
-         order by day
+         group by cast(po.createdAt as date)
+         order by cast(po.createdAt as date)
     """)
     List<Object[]> sumDailyBetween(@Param("start") LocalDateTime start,
                                    @Param("end") LocalDateTime end);

--- a/src/main/java/cotw/server/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/cotw/server/domain/payment/repository/PaymentOrderRepository.java
@@ -16,6 +16,7 @@ import org.springframework.data.repository.query.Param;
 
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -119,5 +120,48 @@ public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long
     Page<AdminDonationListItemResponse> searchDonations(@Param("search") String search,
                                                         @Param("status") PaymentStatus status,
                                                         Pageable pageable);
+    // ===== 대시보드: 기간별 집계 =====
+
+    @Query("""
+        select coalesce(sum(po.amount), 0)
+          from PaymentOrder po
+         where po.status = cotw.server.domain.payment.entity.PaymentStatus.DONE
+           and po.createdAt >= :start and po.createdAt < :end
+    """)
+    long sumDoneBetween(@Param("start") LocalDateTime start,
+                        @Param("end") LocalDateTime end);
+
+    @Query("""
+        select count(po)
+          from PaymentOrder po
+         where po.status = :status
+           and po.createdAt >= :start and po.createdAt < :end
+    """)
+    long countByStatusBetween(@Param("status") PaymentStatus status,
+                              @Param("start") LocalDateTime start,
+                              @Param("end") LocalDateTime end);
+
+    @Query("""
+        select count(distinct po.member.id)
+          from PaymentOrder po
+         where po.status = :status
+           and po.createdAt >= :start and po.createdAt < :end
+    """)
+    long countDistinctMemberByStatusBetween(@Param("status") PaymentStatus status,
+                                            @Param("start") LocalDateTime start,
+                                            @Param("end") LocalDateTime end);
+
+    @Query("""
+        select function('date', po.createdAt) as day, sum(po.amount)
+          from PaymentOrder po
+         where po.status = cotw.server.domain.payment.entity.PaymentStatus.DONE
+           and po.createdAt >= :start and po.createdAt < :end
+         group by function('date', po.createdAt)
+         order by day
+    """)
+    List<Object[]> sumDailyBetween(@Param("start") LocalDateTime start,
+                                   @Param("end") LocalDateTime end);
+
+    List<PaymentOrder> findTop5ByStatusOrderByCreatedAtDesc(PaymentStatus status);
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✅ 작업 내용
 관리자 대시보드 API 구현 ( 최근 기부내역, 최근 신고내역)
- PaymentOrderRepository: 기간별 합계/일간 집계 쿼리 추가
- MemberRepository: KPI용 집계 메서드 추가
- CommentRepository: 대시보드용 신고/숨김 카운트 메서드 추가
- AdminDashboardService: 일간 기부액 추이 집계 및 변환 로직 단순화

## 기타 (선택)